### PR TITLE
add browse abandonment support

### DIFF
--- a/lib/nacelle-pushowl-plugin.js
+++ b/lib/nacelle-pushowl-plugin.js
@@ -5,7 +5,7 @@ const decodeBase64Id = (encodedId) => {
 
   if (encodedId && typeof encodedId === 'string') {
     const base64id = encodedId.split('::').shift()
-    return Buffer.from(base64id, 'base64').toString('binary').split('/').pop()
+    return atob(base64id).split('/').pop()
   }
   return encodedId
 }
@@ -30,6 +30,13 @@ const cartToPushOwlObject = (cart) => {
     checkoutToken,
     items
   }
+}
+
+const handleProductView = (product) => {
+  let productId = parseInt(decodeBase64Id(product.pimSyncSourceProductId), 10)
+  window.pushowl.trigger('syncProductView', {
+    productId
+  })
 }
 
 const setCustomer = (customer) => {
@@ -97,6 +104,17 @@ export default function (ctx) {
     ) {
       const cart = cartToPushOwlObject(state.cart)
       window.pushowl.trigger('syncCart', cart)
+      return
+    }
+
+    // PRODUCT_VIEW event can fire outside of product pages, so explicitly check for product url
+    if (
+      type === 'events/addEvent' &&
+      payload.eventType === 'PRODUCT_VIEW' &&
+      location.pathname.startsWith('/products/')
+    ) {
+      handleProductView(payload.product)
+      return
     }
 
     /**


### PR DESCRIPTION
Remember, a new function called `syncProductView` was added to our SDK? All we are doing here is detecting a product page view in Nacelle's context and triggering our SDK function with the product ID.