### PR TITLE
Removing price drop API from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ If the store URL you see above is not the right store URL where products are ava
 
 - There is a global object available called `pushowl` which can be accessed through `window.pushowl`.
 - The API works by triggering appropriate **"actions"**. An action can be triggered like so: `window.pushowl.trigger(<action_name>, <options>)`. Eg. An action named "X" can be triggered through `window.pushowl.trigger("X")`
+- Widgets for price drop and back in stock are displayed automatically
 
 Available API actions:
 
@@ -125,7 +126,7 @@ Available API actions:
 
 **Options available**
 
-- `type`: Type of widget to show. `browserPrompt`|`customPrompt`|`backInStock`|`priceDrop`
+- `type`: Type of widget to show. `browserPrompt`|`customPrompt`
 
 For `customPrompt`, following extra options are available:
 
@@ -137,16 +138,6 @@ For `customPrompt`, following extra options are available:
 - `position` _(optional)_: Needs to be specified for desktop and mobile separately like so `position: {default: 'top-left', mobile: 'top'}`. Available options for desktop(default): `top-left`, `top-center`, `top-right`, `bottom-left`, `bottom-center`, `bottom-right`. Available options for mobile: `top`, `bottom`. Default is `{ default: 'top-center', mobile: 'top' }`
 - `overlay` _(optional)_: Controls the overlay that shows with the native permission prompt. Only accepts one property for now: `enabled: true|false`. Eg. `overlay: { enabled: false }`
 - `theme` _(optional)_: Allows changing various colors in the prompt. Currently supported properties are: `theme: { yesButtonBgColor: '#f00', yesButtonColor: '#fff' }`
-
-For `priceDrop` and `backInStock`
-
-- `product`: Product to which user subscribed price drop / back in stock notification. `product` requires the following keys
-  - `id`: It of the product as number
-  - `title`: Title of the product
-- `variant`: Selected variant of the above product which user subscribed to. `variant` requires the following keys
-  - `id`: It of the variant as number
-  - `title`: Title of the variant
-  - `price`: Price of the current variant as float
 
 ### `syncCart`
 


### PR DESCRIPTION
Removing price drop and back in stock API from README since those widgets are displayed automatically by the plugin 